### PR TITLE
member service 의존성 주입

### DIFF
--- a/src/main/java/com/exercise/inflearnmembermanagement/service/MemberService.java
+++ b/src/main/java/com/exercise/inflearnmembermanagement/service/MemberService.java
@@ -9,8 +9,11 @@ import java.util.Optional;
 
 public class MemberService {
 
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
+    private final MemberRepository memberRepository;
 
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     /**
      * 회원 가입

--- a/src/test/java/com/exercise/inflearnmembermanagement/service/MemberServiceTest.java
+++ b/src/test/java/com/exercise/inflearnmembermanagement/service/MemberServiceTest.java
@@ -1,0 +1,77 @@
+package com.exercise.inflearnmembermanagement.service;
+
+import com.exercise.inflearnmembermanagement.domain.Member;
+import com.exercise.inflearnmembermanagement.repository.MemoryMemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MemberServiceTest {
+
+    MemberService memberService;
+    MemoryMemberRepository memberRepository;
+
+    @BeforeEach
+    public void beforeEach() {
+        memberRepository = new MemoryMemberRepository();
+        memberService = new MemberService(memberRepository);
+    }
+
+
+    @AfterEach
+    public void afterEach() {
+        memberRepository.clearStore();
+    }
+
+    @Test
+    void 회원가입() {
+        // given
+        Member member = new Member();
+        member.setName("spring");
+
+        // when
+        Long saveId = memberService.join(member);
+
+        // then
+        Member findMember = memberService.findOne(saveId).get();
+
+        assertThat(member.getName()).isEqualTo(findMember.getName());
+    }
+
+    @Test
+    public void 중복_회원_예외() {
+        // given
+        Member member1 = new Member();
+        member1.setName("spring");
+
+        Member member2 = new Member();
+        member2.setName("spring");
+        // when
+        memberService.join(member1);
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> memberService.join(member2));
+
+        assertThat(e.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+
+
+        /*try {
+            memberService.join(member2);
+            fail();
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+        }*/
+        // then
+
+    }
+
+    @Test
+    void findMembers() {
+
+    }
+
+    @Test
+    void findOne() {
+    }
+}


### PR DESCRIPTION
member service에서 사용하는 member repository의 경우 생성자를 통해 생성되기 때문에 
memberServiceTest 에서 사용하는 memberService의 repository와 따로 존재하는 memberRepository가 다른 인스턴스인 문제가 발생합니다.

현재는 memberRepository에서 static 으로 store 를 관리하고 있기 때문에 문제가 없을 수도 있지만 나중을 위해 하나의 인스턴스로 관리될 수 있도록 `Dependency Injection` 을 적용했습니다.