### PR TITLE
Bean 등록 방식 변경

### DIFF
--- a/src/main/java/com/exercise/inflearnmembermanagement/SpringConfig.java
+++ b/src/main/java/com/exercise/inflearnmembermanagement/SpringConfig.java
@@ -1,0 +1,21 @@
+package com.exercise.inflearnmembermanagement;
+
+import com.exercise.inflearnmembermanagement.repository.MemberRepository;
+import com.exercise.inflearnmembermanagement.repository.MemoryMemberRepository;
+import com.exercise.inflearnmembermanagement.service.MemberService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringConfig {
+
+    @Bean
+    public MemberService memberService() {
+        return new MemberService(memberRepository());
+    }
+
+    @Bean
+    public MemberRepository memberRepository() {
+        return new MemoryMemberRepository();
+    }
+}

--- a/src/main/java/com/exercise/inflearnmembermanagement/repository/MemoryMemberRepository.java
+++ b/src/main/java/com/exercise/inflearnmembermanagement/repository/MemoryMemberRepository.java
@@ -1,11 +1,9 @@
 package com.exercise.inflearnmembermanagement.repository;
 
 import com.exercise.inflearnmembermanagement.domain.Member;
-import org.springframework.stereotype.Repository;
 
 import java.util.*;
 
-@Repository
 public class MemoryMemberRepository implements MemberRepository {
 
     private static Map<Long, Member> store = new HashMap<>();

--- a/src/main/java/com/exercise/inflearnmembermanagement/service/MemberService.java
+++ b/src/main/java/com/exercise/inflearnmembermanagement/service/MemberService.java
@@ -2,19 +2,15 @@ package com.exercise.inflearnmembermanagement.service;
 
 import com.exercise.inflearnmembermanagement.domain.Member;
 import com.exercise.inflearnmembermanagement.repository.MemberRepository;
-import com.exercise.inflearnmembermanagement.repository.MemoryMemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
-@Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Autowired
+
     public MemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }


### PR DESCRIPTION
기존 `Component Scan` 방식으로 빈을 등록하던 것과 다르게, 
추후에 `MemoryMemberRepository` 방식을 사용하지 않고 DB 연동 방식을 사용할 수 있습니다.
따라서, 변경 사항 발생 가능성을 고려하여 `Component Scan` 방식 대신에 `Configuration` 방식을 사용하여 Bean 을 생성하도록 변경하였습니다.